### PR TITLE
Add `display.headers` config

### DIFF
--- a/docs/source/usage/commands/alias/activity.rst
+++ b/docs/source/usage/commands/alias/activity.rst
@@ -11,14 +11,17 @@ alias activity
      prompted to choose one.
 
    Options:
-     -i, --include TEXT  A comma-separated list of fields to include in the
-                         resulting table. Only fields in this list will appear.
-                         Omit this option to show all fields.
-     -e, --exclude TEXT  A comma-separated list of fields to exclude from the
-                         resulting table. Useful if you want to view most fields
-                         but leave a few out, rather than specifying a longer
-                         list with `--include`.
-     -h, --help          Show this message and exit.
+     -i, --include TEXT      A comma-separated list of fields to include in the
+                             resulting table. Only fields in this list will
+                             appear. Omit this option to show all fields.
+     -e, --exclude TEXT      A comma-separated list of fields to exclude from the
+                             resulting table. Useful if you want to view most
+                             fields but leave a few out, rather than specifying a
+                             longer list with `--include`.
+     --header / --no-header  Whether to show a header above the items. If
+                             provided, this overrides your `display.headers`
+                             config.
+     -h, --help              Show this message and exit.
 
      Examples
 

--- a/docs/source/usage/commands/alias/contact/list.rst
+++ b/docs/source/usage/commands/alias/contact/list.rst
@@ -4,29 +4,32 @@ alias contact list
 .. code-block:: console
 
    Usage: simplelogin alias contact list [OPTIONS] ID
-   
+
      List contacts for the alias with the given `ID`
-   
+
    Options:
-     -i, --include TEXT  A comma-separated list of fields to include in the
-                         resulting table. Only fields in this list will appear.
-                         Omit this option to show all fields.
-     -e, --exclude TEXT  A comma-separated list of fields to exclude from the
-                         resulting table. Useful if you want to view most fields
-                         but leave a few out, rather than specifying a longer
-                         list with `--include`.
-     -h, --help          Show this message and exit.
-   
+     -i, --include TEXT      A comma-separated list of fields to include in the
+                             resulting table. Only fields in this list will
+                             appear. Omit this option to show all fields.
+     -e, --exclude TEXT      A comma-separated list of fields to exclude from the
+                             resulting table. Useful if you want to view most
+                             fields but leave a few out, rather than specifying a
+                             longer list with `--include`.
+     --header / --no-header  Whether to show a header above the items. If
+                             provided, this overrides your `display.headers`
+                             config.
+     -h, --help              Show this message and exit.
+
      Examples
-   
+
      Show only id and contact fields: `list -i 'id,contact'`
-   
+
      Show all fields except for block_forward: `list -e 'block_forward'`
-   
+
      Show id, contact, and block_forward fields, except for block_forward: `list
      -i 'id,contact,block_forward' -e 'block_forward'` (this is more easily
      expressed as `list -i 'id,contact'`, but it is possible to use both options
      together nonetheless.)
-   
+
      Valid fields: id, contact, reverse_alias, reverse_alias_address,
      block_forward, last_email_sent_timestamp, creation_timestamp

--- a/docs/source/usage/commands/alias/get.rst
+++ b/docs/source/usage/commands/alias/get.rst
@@ -10,11 +10,14 @@ alias get
      cases, if more than one alias matches, you will be prompted to choose one.
 
    Options:
-     -i, --include TEXT  A comma-separated list of fields to include in the
-                         resulting table. Only fields in this list will appear.
-                         Omit this option to show all fields.
-     -e, --exclude TEXT  A comma-separated list of fields to exclude from the
-                         resulting table. Useful if you want to view most fields
-                         but leave a few out, rather than specifying a longer
-                         list with `--include`.
-     -h, --help          Show this message and exit.
+     -i, --include TEXT      A comma-separated list of fields to include in the
+                             resulting table. Only fields in this list will
+                             appear. Omit this option to show all fields.
+     -e, --exclude TEXT      A comma-separated list of fields to exclude from the
+                             resulting table. Useful if you want to view most
+                             fields but leave a few out, rather than specifying a
+                             longer list with `--include`.
+     --header / --no-header  Whether to show a header above the items. If
+                             provided, this overrides your `display.headers`
+                             config.
+     -h, --help              Show this message and exit.

--- a/docs/source/usage/commands/alias/list.rst
+++ b/docs/source/usage/commands/alias/list.rst
@@ -4,32 +4,35 @@ alias list
 .. code-block:: console
 
    Usage: simplelogin alias list [OPTIONS]
-   
+
      List all your aliases
-   
+
    Options:
-     -i, --include TEXT  A comma-separated list of fields to include in the
-                         resulting table. Only fields in this list will appear.
-                         Omit this option to show all fields.
-     -e, --exclude TEXT  A comma-separated list of fields to exclude from the
-                         resulting table. Useful if you want to view most fields
-                         but leave a few out, rather than specifying a longer
-                         list with `--include`.
-     -p, --pinned        Get only pinned aliases
-     -n, --enabled       Get only enabled aliases
-     -d, --disabled      Get only disabled aliases
-     -h, --help          Show this message and exit.
-   
+     -i, --include TEXT      A comma-separated list of fields to include in the
+                             resulting table. Only fields in this list will
+                             appear. Omit this option to show all fields.
+     -e, --exclude TEXT      A comma-separated list of fields to exclude from the
+                             resulting table. Useful if you want to view most
+                             fields but leave a few out, rather than specifying a
+                             longer list with `--include`.
+     -p, --pinned            Get only pinned aliases
+     -n, --enabled           Get only enabled aliases
+     -d, --disabled          Get only disabled aliases
+     --header / --no-header  Whether to show a header above the items. If
+                             provided, this overrides your `display.headers`
+                             config.
+     -h, --help              Show this message and exit.
+
      Examples
-   
+
      Show only id and email fields: `list -i 'id,email'`
-   
+
      Show all fields except for name: `list -e 'name'`
-   
+
      Show id, email, and name fields, except for name: `list -i 'id,email,name'
      -e 'name'` (this is more easily expressed as `list -i 'id,email'`, but it is
      possible to use both options together nonetheless.)
-   
+
      Valid fields: id, email, name, note, enabled, nb_block, nb_forward,
      nb_reply, mailboxes, latest_activity, support_pgp, disable_pgp, pinned,
      creation_timestamp

--- a/docs/source/usage/commands/mailbox/list.rst
+++ b/docs/source/usage/commands/mailbox/list.rst
@@ -4,27 +4,30 @@ mailbox list
 .. code-block:: console
 
    Usage: simplelogin mailbox list [OPTIONS]
-   
+
      Display all your mailboxes
-   
+
    Options:
-     -i, --include TEXT  A comma-separated list of fields to include in the
-                         resulting table. Only fields in this list will appear.
-                         Omit this option to show all fields.
-     -e, --exclude TEXT  A comma-separated list of fields to exclude from the
-                         resulting table. Useful if you want to view most fields
-                         but leave a few out, rather than specifying a longer
-                         list with `--include`.
-     -h, --help          Show this message and exit.
-   
+     -i, --include TEXT      A comma-separated list of fields to include in the
+                             resulting table. Only fields in this list will
+                             appear. Omit this option to show all fields.
+     -e, --exclude TEXT      A comma-separated list of fields to exclude from the
+                             resulting table. Useful if you want to view most
+                             fields but leave a few out, rather than specifying a
+                             longer list with `--include`.
+     --header / --no-header  Whether to show a header above the items. If
+                             provided, this overrides your `display.headers`
+                             config.
+     -h, --help              Show this message and exit.
+
      Examples
-   
+
      Show only id and email fields: `list -i 'id,email'`
-   
+
      Show all fields except for default: `list -e 'default'`
-   
+
      Show id, email, and default fields, except for default: `list -i
      'id,email,default' -e 'default'` (this is more easily expressed as `list -i
      'id,email'`, but it is possible to use both options together nonetheless.)
-   
+
      Valid fields: id, email, nb_alias, verified, default, creation_timestamp

--- a/simplelogincmd/cli/commands/_config.py
+++ b/simplelogincmd/cli/commands/_config.py
@@ -7,6 +7,9 @@ def _display_config_value(key, value):
     if key == "api.api-key":
         # Obscure for security.
         value = "*" * 20
+    elif isinstance(value, bool):
+        # Display in lowercase.
+        value = "true" if value else "false"
     click.echo(f"{key} = {value}")
 
 

--- a/simplelogincmd/cli/commands/alias_commands/_activity.py
+++ b/simplelogincmd/cli/commands/alias_commands/_activity.py
@@ -4,7 +4,7 @@ from simplelogincmd.cli import const, util
 from simplelogincmd.database.models import Alias
 
 
-def _activity(id, include, exclude):
+def _activity(id, include, exclude, header):
     fields = util.output.get_display_fields_from_options(
         const.ACTIVITY_FIELD_ORDER, include, exclude
     )
@@ -19,4 +19,11 @@ def _activity(id, include, exclude):
         click.echo("No activities found")
         return
     pager_threshold = cfg.get("display.pager-threshold")
-    util.output.display_model_list(activities, fields, pager_threshold)
+    if header is None:
+        header = cfg.get("display.headers")
+    util.output.display_model_list(
+        activities,
+        fields,
+        pager_threshold,
+        header,
+    )

--- a/simplelogincmd/cli/commands/alias_commands/_get.py
+++ b/simplelogincmd/cli/commands/alias_commands/_get.py
@@ -4,7 +4,7 @@ from simplelogincmd.cli import const, util
 from simplelogincmd.database.models import Alias
 
 
-def _get(id, include, exclude):
+def _get(id, include, exclude, header):
     fields = util.output.get_display_fields_from_options(
         const.ALIAS_FIELD_ORDER, include, exclude
     )
@@ -20,4 +20,11 @@ def _get(id, include, exclude):
         return None
     db.session.upsert(obj)
     db.session.commit()
-    util.output.display_model_list([obj], fields, pager_threshold=0)
+    if header is None:
+        header = cfg.get("display.headers")
+    util.output.display_model_list(
+        [obj],
+        fields,
+        pager_threshold=0,
+        header=header,
+    )

--- a/simplelogincmd/cli/commands/alias_commands/_list.py
+++ b/simplelogincmd/cli/commands/alias_commands/_list.py
@@ -4,7 +4,7 @@ from simplelogincmd.cli import const
 from simplelogincmd.cli.util import init, output
 
 
-def _list(include, exclude, query):
+def _list(include, exclude, query, header):
     fields = output.get_display_fields_from_options(
         const.ALIAS_FIELD_ORDER, include, exclude
     )
@@ -21,4 +21,11 @@ def _list(include, exclude, query):
         db.session.upsert(alias)
     db.session.commit()
     pager_threshold = cfg.get("display.pager-threshold")
-    output.display_model_list(aliases, fields, pager_threshold)
+    if header is None:
+        header = cfg.get("display.headers")
+    output.display_model_list(
+        aliases,
+        fields,
+        pager_threshold,
+        header,
+    )

--- a/simplelogincmd/cli/commands/alias_commands/activity.py
+++ b/simplelogincmd/cli/commands/alias_commands/activity.py
@@ -22,8 +22,19 @@ from simplelogincmd.cli import const
     "--exclude",
     help=const.HELP.ALIAS.ACTIVITY.OPTION.EXCLUDE,
 )
-def activity(id: str, include: str | None, exclude: str | None) -> None:
+@click.option(
+    "--header/--no-header",
+    "header",
+    default=None,
+    help=const.HELP.ALIAS.ACTIVITY.OPTION.HEADER,
+)
+def activity(
+    id: str,
+    include: str | None,
+    exclude: str | None,
+    header: bool | None,
+) -> None:
     """Display alias activities in a tabular format"""
     from simplelogincmd.cli.commands.alias_commands._activity import _activity
 
-    return _activity(id, include, exclude)
+    return _activity(id, include, exclude, header)

--- a/simplelogincmd/cli/commands/alias_commands/contact_commands/_list.py
+++ b/simplelogincmd/cli/commands/alias_commands/contact_commands/_list.py
@@ -4,7 +4,7 @@ from simplelogincmd.cli import const, util
 from simplelogincmd.database.models import Alias
 
 
-def _list(id, include, exclude):
+def _list(id, include, exclude, header):
     fields = util.output.get_display_fields_from_options(
         const.CONTACT_FIELD_ORDER, include, exclude
     )
@@ -22,4 +22,11 @@ def _list(id, include, exclude):
         db.session.upsert(contact)
     db.session.commit()
     pager_threshold = cfg.get("display.pager-threshold")
-    util.output.display_model_list(contacts, fields, pager_threshold)
+    if header is None:
+        header = cfg.get("display.headers")
+    util.output.display_model_list(
+        contacts,
+        fields,
+        pager_threshold,
+        header,
+    )

--- a/simplelogincmd/cli/commands/alias_commands/contact_commands/list.py
+++ b/simplelogincmd/cli/commands/alias_commands/contact_commands/list.py
@@ -22,8 +22,19 @@ from simplelogincmd.cli import const
     "--exclude",
     help=const.HELP.ALIAS.CONTACT.LIST.OPTION.EXCLUDE,
 )
-def list(id: str, include: str | None, exclude: str | None) -> None:
+@click.option(
+    "--header/--no-header",
+    "header",
+    default=None,
+    help=const.HELP.ALIAS.CONTACT.LIST.OPTION.HEADER,
+)
+def list(
+    id: str,
+    include: str | None,
+    exclude: str | None,
+    header: bool | None,
+) -> None:
     """List contacts in a tabular format"""
     from simplelogincmd.cli.commands.alias_commands.contact_commands._list import _list
 
-    return _list(id, include, exclude)
+    return _list(id, include, exclude, header)

--- a/simplelogincmd/cli/commands/alias_commands/get.py
+++ b/simplelogincmd/cli/commands/alias_commands/get.py
@@ -21,8 +21,19 @@ from simplelogincmd.cli import const
     "--exclude",
     help=const.HELP.ALIAS.GET.OPTION.EXCLUDE,
 )
-def get(id: str, include: str | None, exclude: str | None) -> None:
+@click.option(
+    "--header/--no-header",
+    "header",
+    default=None,
+    help=const.HELP.ALIAS.GET.OPTION.HEADER,
+)
+def get(
+    id: str,
+    include: str | None,
+    exclude: str | None,
+    header: bool | None,
+) -> None:
     """Display a single alias in a tabular format"""
     from simplelogincmd.cli.commands.alias_commands._get import _get
 
-    return _get(id, include, exclude)
+    return _get(id, include, exclude, header)

--- a/simplelogincmd/cli/commands/alias_commands/list.py
+++ b/simplelogincmd/cli/commands/alias_commands/list.py
@@ -40,8 +40,19 @@ from simplelogincmd.cli import const
     flag_value="disabled",
     help=const.HELP.ALIAS.LIST.OPTION.DISABLED,
 )
-def list(include: str | None, exclude: str | None, query: str | None) -> None:
+@click.option(
+    "--header/--no-header",
+    "header",
+    default=None,
+    help=const.HELP.ALIAS.LIST.OPTION.HEADER,
+)
+def list(
+    include: str | None,
+    exclude: str | None,
+    query: str | None,
+    header: bool | None,
+) -> None:
     """Display aliases in a tabular format"""
     from simplelogincmd.cli.commands.alias_commands._list import _list
 
-    return _list(include, exclude, query)
+    return _list(include, exclude, query, header)

--- a/simplelogincmd/cli/commands/mailbox_commands/_list.py
+++ b/simplelogincmd/cli/commands/mailbox_commands/_list.py
@@ -18,7 +18,7 @@ def _mailbox_sort_key(mailbox: Mailbox) -> tuple[int, str]:
     return (mailbox.nb_alias * -1, mailbox.email)
 
 
-def _list(include, exclude):
+def _list(include, exclude, header):
     fields = output.get_display_fields_from_options(
         const.MAILBOX_FIELD_ORDER, include, exclude
     )
@@ -34,4 +34,11 @@ def _list(include, exclude):
     for mailbox in mailboxes:
         db.session.upsert(mailbox)
     db.session.commit()
-    output.display_model_list(mailboxes, fields, pager_threshold=0)
+    if header is None:
+        header = cfg.get("display.headers")
+    output.display_model_list(
+        mailboxes,
+        fields,
+        pager_threshold=0,
+        header=header,
+    )

--- a/simplelogincmd/cli/commands/mailbox_commands/list.py
+++ b/simplelogincmd/cli/commands/mailbox_commands/list.py
@@ -19,8 +19,18 @@ from simplelogincmd.cli import const
     "--exclude",
     help=const.HELP.MAILBOX.LIST.OPTION.EXCLUDE,
 )
-def list(include: str, exclude: str) -> None:
+@click.option(
+    "--header/--no-header",
+    "header",
+    default=None,
+    help=const.HELP.MAILBOX.LIST.OPTION.HEADER,
+)
+def list(
+    include: str,
+    exclude: str,
+    header: bool | None,
+) -> None:
     """Display mailboxes in a tabular format"""
     from simplelogincmd.cli.commands.mailbox_commands._list import _list
 
-    return _list(include, exclude)
+    return _list(include, exclude, header)

--- a/simplelogincmd/cli/const.py
+++ b/simplelogincmd/cli/const.py
@@ -78,6 +78,10 @@ _HELP_MAILBOX_ID = (
     "base, its email address. In the latter case, if more than one "
     "mailbox matches, you will be prompted to choose one."
 )
+_HELP_OPTION_HEADER = (
+    "Whether to show a header above the items. If provided, this "
+    "overrides your `display.headers` config."
+)
 _HELP_OPTION_NOTE = (
     "Attach a note to the item. Setting this switch with"
     "out providing any value will open an editor in which you can enter "
@@ -158,6 +162,7 @@ HELP = NS(
             OPTION=NS(
                 INCLUDE=_HELP_LIST_INCLUDE,
                 EXCLUDE=_HELP_LIST_EXCLUDE,
+                HEADER=_HELP_OPTION_HEADER,
             ),
         ),
         CONTACT=NS(
@@ -182,6 +187,7 @@ HELP = NS(
                 OPTION=NS(
                     INCLUDE=_HELP_LIST_INCLUDE,
                     EXCLUDE=_HELP_LIST_EXCLUDE,
+                    HEADER=_HELP_OPTION_HEADER,
                 ),
             ),
         ),
@@ -228,6 +234,7 @@ HELP = NS(
             OPTION=NS(
                 INCLUDE=_HELP_LIST_INCLUDE,
                 EXCLUDE=_HELP_LIST_EXCLUDE,
+                HEADER=_HELP_OPTION_HEADER,
             ),
         ),
         LIST=NS(
@@ -245,6 +252,7 @@ HELP = NS(
                 PINNED="Get only pinned aliases",
                 ENABLED="Get only enabled aliases",
                 DISABLED="Get only disabled aliases",
+                HEADER=_HELP_OPTION_HEADER,
             ),
         ),
         RANDOM=NS(
@@ -347,6 +355,7 @@ HELP = NS(
             OPTION=NS(
                 INCLUDE=_HELP_LIST_INCLUDE,
                 EXCLUDE=_HELP_LIST_EXCLUDE,
+                HEADER=_HELP_OPTION_HEADER,
             ),
         ),
         UPDATE=NS(

--- a/simplelogincmd/cli/util/output.py
+++ b/simplelogincmd/cli/util/output.py
@@ -41,7 +41,7 @@ def get_display_fields_from_options(
     return fields
 
 
-def _generate_model_list(models: list, fields: list[str]):
+def _generate_model_list(models: list, fields: list[str], header: bool):
     """
     Generate a table displaying the given fields of each item
 
@@ -50,14 +50,19 @@ def _generate_model_list(models: list, fields: list[str]):
     :type models: list[Object]
     :param fields: The field names to be shown for each item
     :type fields: list[str]
+    :param header: Whether to include a header of field names as the
+        first line
+    :type header: bool
 
     :return: A generator of each line of the table, including a heading
+        if desired
     :rtype: Generator
     """
     if len(models) == 0:
         return
-    header = "|".join(fields)
-    yield f"{header}\n"
+    if header:
+        header = "|".join(fields)
+        yield f"{header}\n"
     for model in models:
         properties = [model.get_string(field) for field in fields]
         entry = "|".join(properties)
@@ -68,6 +73,7 @@ def display_model_list(
     models: list,
     fields: list[str],
     pager_threshold: int,
+    header: bool = True,
 ) -> None:
     """
     Print a simple table detailing each item to stdout
@@ -82,15 +88,19 @@ def display_model_list(
         consists of this many or more entries, including the heading.
         A value of `0` indicates not to use the pager.
     :type use_pager: int
+    :param header: Whether to include a header of field names as the
+        first line, defaults to True
+    :type header: bool
 
     :rtype: None
     """
     count = len(models)
     if count == 0:
         return
-    table = _generate_model_list(models, fields)
-    # +1 to account for the heading.
-    if 0 < pager_threshold <= count + 1:
+    if header:
+        count += 1
+    table = _generate_model_list(models, fields, header)
+    if 0 < pager_threshold <= count:
         click.echo_via_pager(table)
         return
     for entry in table:

--- a/simplelogincmd/const.py
+++ b/simplelogincmd/const.py
@@ -39,6 +39,9 @@ CONFIG_SCHEMA = {
                     "type": "integer",
                     "minimum": 0,
                 },
+                "headers": {
+                    "type": "boolean",
+                },
             },
         },
     },
@@ -50,5 +53,6 @@ CONFIG_BASE = {
     },
     "display": {
         "pager-threshold": 20,
+        "headers": True,
     },
 }


### PR DESCRIPTION
- New config setting, `display.headers`, to control whether field names are shown by default above lists of mailboxes, aliases, etc.
- Update `simplelogincmd.cli.util.output.display_model_list()` to accept a new argument, `header`, which determines whether to include a header in the output
- Update all commands that display these lists (`alias activity`, `alias get`, `alias list`, `alias contact list`, and `alias mailbox`) to check for the new config setting and act accordingly.
- They also all accept a new `--header/--no-header` flag option which, if set, temporarily overrides the setting for the duration of that particular invocation
- Display the value of boolean config settings in lowercase, rather than capitalizing the first letter as Python would do