### PR TITLE
Add `alias contact delete` command

### DIFF
--- a/docs/source/usage/commands/alias/contact/contact.rst
+++ b/docs/source/usage/commands/alias/contact/contact.rst
@@ -17,4 +17,5 @@ alias contact
 .. toctree::
 
    create
+   delete
    list

--- a/docs/source/usage/commands/alias/contact/delete.rst
+++ b/docs/source/usage/commands/alias/contact/delete.rst
@@ -1,0 +1,14 @@
+alias contact delete
+====================
+
+.. code-block:: console
+
+   Usage: simplelogin alias contact delete [OPTIONS] ID
+
+     Delete the contact with the given ID. `ID` can be the contact's numeric id
+     or, if you have a local database, its email address. In the latter case, if
+     more than one contact matches, you will be prompted to choose one.
+
+   Options:
+     -y, --yes   Bypass the confirmation prompt
+     -h, --help  Show this message and exit.

--- a/simplelogincmd/cli/commands/alias_commands/contact_commands/_delete.py
+++ b/simplelogincmd/cli/commands/alias_commands/contact_commands/_delete.py
@@ -1,0 +1,22 @@
+import click
+
+from simplelogincmd.cli.util import init, input
+from simplelogincmd.database.models import Contact
+
+
+def _delete(id, bypass_confirmation):
+    cfg = init.cfg()
+    sl = init.sl(cfg)
+    db = init.db(cfg)
+    id = input.resolve_id(db, Contact, id)
+    if not bypass_confirmation:
+        contact = db.session.get(Contact, id)
+        msg = f"Delete {contact.contact if contact else id}?"
+        click.confirm(msg, abort=True)
+    success, msg = sl.delete_contact(id)
+    if not success:
+        # Clarify the somewhat vague error message
+        msg = f"Unknown ID {id}" if msg == "Forbidden" else msg
+        click.echo(msg)
+        return False
+    return True

--- a/simplelogincmd/cli/commands/alias_commands/contact_commands/delete.py
+++ b/simplelogincmd/cli/commands/alias_commands/contact_commands/delete.py
@@ -1,0 +1,29 @@
+import click
+
+from simplelogincmd.cli import const
+
+
+@click.command(
+    "delete",
+    short_help=const.HELP.ALIAS.CONTACT.DELETE.SHORT,
+    help=const.HELP.ALIAS.CONTACT.DELETE.LONG,
+)
+@click.argument(
+    "id",
+)
+@click.option(
+    "-y",
+    "--yes",
+    "bypass_confirmation",
+    is_flag=True,
+    flag_value=True,
+    default=False,
+    help=const.HELP.ALIAS.CONTACT.DELETE.OPTION.YES,
+)
+def delete(id: str, bypass_confirmation: bool) -> bool:
+    """Delete a contact"""
+    from simplelogincmd.cli.commands.alias_commands.contact_commands._delete import (
+        _delete,
+    )
+
+    return _delete(id, bypass_confirmation)

--- a/simplelogincmd/cli/const.py
+++ b/simplelogincmd/cli/const.py
@@ -73,6 +73,11 @@ _HELP_ALIAS_ID = (
     "base, either its email address or note. In the latter cases, if "
     "more than one alias matches, you will be prompted to choose one."
 )
+_HELP_CONTACT_ID = (
+    "`ID` can be the contact's numeric id or, if you have a local data"
+    "base, its email address. In the latter case, if more than one "
+    "contact matches, you will be prompted to choose one."
+)
 _HELP_MAILBOX_ID = (
     "`ID` can be the mailbox's numeric id or, if you have a local data"
     "base, its email address. In the latter case, if more than one "
@@ -173,6 +178,13 @@ HELP = NS(
                 LONG=f"Add a contact to the alias with the given ID`. {_HELP_ALIAS_ID}",
                 OPTION=NS(
                     EMAIL="The contact's email address",
+                ),
+            ),
+            DELETE=NS(
+                SHORT="Delete a contact",
+                LONG=f"Delete the contact with the given ID. {_HELP_CONTACT_ID}",
+                OPTION=NS(
+                    YES="Bypass the confirmation prompt",
                 ),
             ),
             LIST=NS(

--- a/simplelogincmd/rest/const.py
+++ b/simplelogincmd/rest/const.py
@@ -25,6 +25,7 @@ ENDPOINT = NS(
     ALIAS_TOGGLE="/api/aliases/{alias_id}/toggle",
     ALIAS_ACTIVITIES="/api/aliases/{alias_id}/activities",
     ALIAS_CONTACTS="/api/aliases/{alias_id}/contacts",
+    CONTACT="/api/contacts/{contact_id}",
 )
 
 

--- a/simplelogincmd/rest/simplelogin.py
+++ b/simplelogincmd/rest/simplelogin.py
@@ -624,3 +624,21 @@ class SimpleLogin:
         if not success:
             return success, json.get("error", "Failed to create contact")
         return success, Contact(**json)
+
+    def delete_contact(self, contact_id: int) -> tuple[bool, str | None]:
+        """
+        Delete a contact
+
+        See SimpleLogin's documentation for an explanation of the
+        parameters.
+
+        :return: Whether the deletion succeeded, and an optional error
+            message
+        :rtype: tuple[bool, str | None]
+        """
+        endpoint = const.ENDPOINT.CONTACT.format(contact_id=contact_id)
+        headers = self._auth_headers()
+        success, json = self.client.delete(endpoint, headers=headers)
+        if not success:
+            return success, json.get("error", "Failed to delete contact")
+        return success, None

--- a/tests/fixtures/responses.py
+++ b/tests/fixtures/responses.py
@@ -322,3 +322,23 @@ def resp_contact_create_unable(
         status=403,
         json=sl_create_contact_unable,
     )
+
+
+@pytest.fixture
+def resp_contact_delete_success(url_contact, sl_contact_a, sl_contact_delete_success):
+    return Response(
+        method="DELETE",
+        url=url_contact.format(contact_id=sl_contact_a["id"]),
+        status=200,
+        json=sl_contact_delete_success,
+    )
+
+
+@pytest.fixture
+def resp_contact_delete_failure(url_contact, sl_contact_a, sl_contact_delete_failure):
+    return Response(
+        method="DELETE",
+        url=url_contact.format(contact_id=sl_contact_a["id"]),
+        status=403,
+        json=sl_contact_delete_failure,
+    )

--- a/tests/fixtures/simplelogin.py
+++ b/tests/fixtures/simplelogin.py
@@ -338,3 +338,17 @@ def sl_create_contact_unable():
     return dict(
         error="Please upgrade to create a reverse-alias",
     )
+
+
+@pytest.fixture
+def sl_contact_delete_success():
+    return dict(
+        deleted=True,
+    )
+
+
+@pytest.fixture
+def sl_contact_delete_failure():
+    return dict(
+        error="Forbidden",
+    )

--- a/tests/fixtures/url.py
+++ b/tests/fixtures/url.py
@@ -68,3 +68,8 @@ def url_alias_activities(url_base):
 @pytest.fixture(scope="session")
 def url_alias_contacts(url_base):
     return urljoin(url_base, const.ENDPOINT.ALIAS_CONTACTS)
+
+
+@pytest.fixture(scope="session")
+def url_contact(url_base):
+    return urljoin(url_base, const.ENDPOINT.CONTACT)

--- a/tests/unit/rest/test_simplelogin.py
+++ b/tests/unit/rest/test_simplelogin.py
@@ -306,3 +306,20 @@ class TestAliasEndpoints:
         )
         assert success is False
         assert "Please upgrade" in obj
+
+
+class TestContactEndpoints:
+
+    @responses.activate
+    def test_delete_valid(self, sl, sl_contact_a, resp_contact_delete_success):
+        responses.add(resp_contact_delete_success)
+        success, msg = sl.delete_contact(contact_id=sl_contact_a["id"])
+        assert success is True
+        assert msg is None
+
+    @responses.activate
+    def test_delete_invalid(self, sl, sl_contact_a, resp_contact_delete_failure):
+        responses.add(resp_contact_delete_failure)
+        success, msg = sl.delete_contact(contact_id=sl_contact_a["id"])
+        assert success is False
+        assert isinstance(msg, str)


### PR DESCRIPTION
A new command, including documentation and tests, for deleting alias contacts.