### PR TITLE
Add `alias contact toggle` command

### DIFF
--- a/docs/source/usage/commands/alias/contact/contact.rst
+++ b/docs/source/usage/commands/alias/contact/contact.rst
@@ -19,3 +19,4 @@ alias contact
    create
    delete
    list
+   toggle

--- a/docs/source/usage/commands/alias/contact/toggle.rst
+++ b/docs/source/usage/commands/alias/contact/toggle.rst
@@ -1,0 +1,14 @@
+alias contact toggle
+====================
+
+.. code-block:: console
+
+   Usage: simplelogin alias contact toggle [OPTIONS] ID
+
+     Block or unblock the contact with the given ID. `ID` can be the contact's
+     numeric id or, if you have a local database, its email address. In the
+     latter case, if more than one contact matches, you will be prompted to
+     choose one.
+
+   Options:
+     -h, --help  Show this message and exit.

--- a/simplelogincmd/cli/commands/alias_commands/contact_commands/_toggle.py
+++ b/simplelogincmd/cli/commands/alias_commands/contact_commands/_toggle.py
@@ -1,0 +1,17 @@
+import click
+
+from simplelogincmd.cli.util import init, input
+from simplelogincmd.database.models import Contact
+
+
+def _toggle(id):
+    cfg = init.cfg()
+    sl = init.sl(cfg)
+    db = init.db(cfg)
+    id = input.resolve_id(db, Contact, id)
+    success, result = sl.toggle_contact(id)
+    if not success:
+        click.echo(result)
+        return False
+    click.echo("Blocked" if result else "Unblocked")
+    return True

--- a/simplelogincmd/cli/commands/alias_commands/contact_commands/toggle.py
+++ b/simplelogincmd/cli/commands/alias_commands/contact_commands/toggle.py
@@ -1,0 +1,20 @@
+import click
+
+from simplelogincmd.cli import const
+
+
+@click.command(
+    "toggle",
+    short_help=const.HELP.ALIAS.CONTACT.TOGGLE.SHORT,
+    help=const.HELP.ALIAS.CONTACT.TOGGLE.LONG,
+)
+@click.argument(
+    "id",
+)
+def toggle(id: str) -> bool:
+    """Enable or disable a contact"""
+    from simplelogincmd.cli.commands.alias_commands.contact_commands._toggle import (
+        _toggle,
+    )
+
+    return _toggle(id)

--- a/simplelogincmd/cli/const.py
+++ b/simplelogincmd/cli/const.py
@@ -202,6 +202,11 @@ HELP = NS(
                     HEADER=_HELP_OPTION_HEADER,
                 ),
             ),
+            TOGGLE=NS(
+                SHORT="Block and unblock a contact",
+                LONG="Block or unblock the contact with the given "
+                f"ID. {_HELP_CONTACT_ID}",
+            ),
         ),
         CUSTOM=NS(
             SHORT=None,

--- a/simplelogincmd/rest/const.py
+++ b/simplelogincmd/rest/const.py
@@ -26,6 +26,7 @@ ENDPOINT = NS(
     ALIAS_ACTIVITIES="/api/aliases/{alias_id}/activities",
     ALIAS_CONTACTS="/api/aliases/{alias_id}/contacts",
     CONTACT="/api/contacts/{contact_id}",
+    CONTACT_TOGGLE="/api/contacts/{contact_id}/toggle",
 )
 
 

--- a/simplelogincmd/rest/simplelogin.py
+++ b/simplelogincmd/rest/simplelogin.py
@@ -642,3 +642,21 @@ class SimpleLogin:
         if not success:
             return success, json.get("error", "Failed to delete contact")
         return success, None
+
+    def toggle_contact(self, contact_id: int) -> tuple[bool, bool | str]:
+        """
+        Block or unblock a contact
+
+        See the Simplelogin documentation for an explanation of the
+        parameters.
+
+        :return: Whether the toggle succeeded, and the contact's new
+            state or an error message, as appropriate
+        :rtype: tuple[bool, bool | str]
+        """
+        endpoint = const.ENDPOINT.CONTACT_TOGGLE.format(contact_id=contact_id)
+        headers = self._auth_headers()
+        success, json = self.client.post(endpoint, headers=headers)
+        if not success:
+            return success, json.get("error", "Failed to toggle contact")
+        return success, json.get("block_forward")

--- a/tests/fixtures/responses.py
+++ b/tests/fixtures/responses.py
@@ -342,3 +342,35 @@ def resp_contact_delete_failure(url_contact, sl_contact_a, sl_contact_delete_fai
         status=403,
         json=sl_contact_delete_failure,
     )
+
+
+@pytest.fixture
+def resp_contact_enabled(url_contact_toggle, sl_contact_a, sl_contact_enabled):
+    return Response(
+        method="POST",
+        url=url_contact_toggle.format(contact_id=sl_contact_a["id"]),
+        status=200,
+        json=sl_contact_enabled,
+    )
+
+
+@pytest.fixture
+def resp_contact_disabled(url_contact_toggle, sl_contact_a, sl_contact_disabled):
+    return Response(
+        method="POST",
+        url=url_contact_toggle.format(contact_id=sl_contact_a["id"]),
+        status=200,
+        json=sl_contact_disabled,
+    )
+
+
+@pytest.fixture
+def resp_contact_toggle_failure(
+    url_contact_toggle, sl_contact_a, sl_contact_toggle_failure
+):
+    return Response(
+        method="POST",
+        url=url_contact_toggle.format(contact_id=sl_contact_a["id"]),
+        status=403,
+        json=sl_contact_toggle_failure,
+    )

--- a/tests/fixtures/simplelogin.py
+++ b/tests/fixtures/simplelogin.py
@@ -352,3 +352,24 @@ def sl_contact_delete_failure():
     return dict(
         error="Forbidden",
     )
+
+
+@pytest.fixture
+def sl_contact_enabled():
+    return dict(
+        block_forward=False,
+    )
+
+
+@pytest.fixture
+def sl_contact_disabled():
+    return dict(
+        block_forward=True,
+    )
+
+
+@pytest.fixture
+def sl_contact_toggle_failure():
+    return dict(
+        error="Forbidden",
+    )

--- a/tests/fixtures/url.py
+++ b/tests/fixtures/url.py
@@ -73,3 +73,8 @@ def url_alias_contacts(url_base):
 @pytest.fixture(scope="session")
 def url_contact(url_base):
     return urljoin(url_base, const.ENDPOINT.CONTACT)
+
+
+@pytest.fixture(scope="session")
+def url_contact_toggle(url_base):
+    return urljoin(url_base, const.ENDPOINT.CONTACT_TOGGLE)

--- a/tests/unit/rest/test_simplelogin.py
+++ b/tests/unit/rest/test_simplelogin.py
@@ -323,3 +323,26 @@ class TestContactEndpoints:
         success, msg = sl.delete_contact(contact_id=sl_contact_a["id"])
         assert success is False
         assert isinstance(msg, str)
+
+    @responses.activate
+    def test_enable_valid(self, sl, sl_contact_a, resp_contact_enabled):
+        responses.add(resp_contact_enabled)
+        success, result = sl.toggle_contact(contact_id=sl_contact_a["id"])
+        assert success is True
+        # `False` indicates not blocked (i.e., enabled).
+        assert result is False
+
+    @responses.activate
+    def test_disable_valid(self, sl, sl_contact_a, resp_contact_disabled):
+        responses.add(resp_contact_disabled)
+        success, result = sl.toggle_contact(contact_id=sl_contact_a["id"])
+        assert success is True
+        # `True` indicates blocked (i.e., disabled).
+        assert result is True
+
+    @responses.activate
+    def test_toggle_invalid(self, sl, sl_contact_a, resp_contact_toggle_failure):
+        responses.add(resp_contact_toggle_failure)
+        success, result = sl.toggle_contact(contact_id=sl_contact_a["id"])
+        assert success is False
+        assert isinstance(result, str)


### PR DESCRIPTION
New command, including docs and tests, for blocking and unblocking alias contacts, filling out our coverage of the contact endpoints.