### PR TITLE
Add missing local db updates

### DIFF
--- a/simplelogincmd/cli/commands/alias_commands/_activity.py
+++ b/simplelogincmd/cli/commands/alias_commands/_activity.py
@@ -10,14 +10,18 @@ def _activity(id, include, exclude, header):
     )
     if len(fields) == 0:
         return
+
     cfg = util.init.cfg()
     sl = util.init.sl(cfg)
     db = util.init.db(cfg)
-    id = util.input.resolve_id(db, Alias, id)
+    if (alias := util.input.resolve_id(db, Alias, id)) is not None:
+        id = alias.id
+
     activities = sl.get_all_alias_activities(id)
     if len(activities) == 0:
         click.echo("No activities found")
         return
+
     pager_threshold = cfg.get("display.pager-threshold")
     if header is None:
         header = cfg.get("display.headers")

--- a/simplelogincmd/cli/commands/alias_commands/_delete.py
+++ b/simplelogincmd/cli/commands/alias_commands/_delete.py
@@ -8,19 +8,25 @@ def _delete(id, bypass_confirmation):
     cfg = init.cfg()
     sl = init.sl(cfg)
     db = init.db(cfg)
-    id = input.resolve_id(db, Alias, id)
+    if (alias := input.resolve_id(db, Alias, id)) is not None:
+        id = alias.id
+        name = alias.email
+    else:
+        name = id
+
     if not bypass_confirmation:
-        success, obj = sl.get_alias(id)
-        if not success:
-            # Clarify the somewhat vague error message for invalid ID
-            msg = f"Unknown ID {id}" if "Unknown" in obj else obj
-            click.echo(msg)
-            return False
-        click.confirm(f"Delete {obj.email}?", abort=True)
+        click.confirm(f"Delete {name}?", abort=True)
+
     success, msg = sl.delete_alias(id)
     if not success:
         # Clarify the somewhat vague error message
         msg = f"Unknown ID {id}" if msg == "Forbidden" else msg
         click.echo(msg)
         return False
+
+    if alias is not None:
+        # Update local db.
+        db.session.delete(alias)
+        db.session.commit()
+
     return True

--- a/simplelogincmd/cli/commands/alias_commands/_get.py
+++ b/simplelogincmd/cli/commands/alias_commands/_get.py
@@ -10,16 +10,22 @@ def _get(id, include, exclude, header):
     )
     if len(fields) == 0:
         return
+
     cfg = util.init.cfg()
     sl = util.init.sl(cfg)
     db = util.init.db(cfg)
-    id = util.input.resolve_id(db, Alias, id)
+    if (alias := util.input.resolve_id(db, Alias, id)) is not None:
+        id = alias.id
+
     success, obj = sl.get_alias(id)
     if not success:
         click.echo(obj)
         return None
+
+    # Update local db.
     db.session.upsert(obj)
     db.session.commit()
+
     if header is None:
         header = cfg.get("display.headers")
     util.output.display_model_list(

--- a/simplelogincmd/cli/commands/alias_commands/_toggle.py
+++ b/simplelogincmd/cli/commands/alias_commands/_toggle.py
@@ -8,10 +8,19 @@ def _toggle(id):
     cfg = init.cfg()
     sl = init.sl(cfg)
     db = init.db(cfg)
-    id = input.resolve_id(db, Alias, id)
+    if (alias := input.resolve_id(db, Alias, id)) is not None:
+        id = alias.id
+
     success, result = sl.toggle_alias(id)
     if not success:
         click.echo(result)
         return False
+
+    if alias is not None:
+        # Update local db.
+        alias.enabled = result
+        db.session.add(alias)
+        db.session.commit()
+
     click.echo("Enabled" if result else "Disabled")
     return True

--- a/simplelogincmd/cli/commands/alias_commands/_update.py
+++ b/simplelogincmd/cli/commands/alias_commands/_update.py
@@ -11,10 +11,20 @@ def _update(id, note, name, mailboxes, disable_pgp, pinned):
     cfg = init.cfg()
     sl = init.sl(cfg)
     db = init.db(cfg)
-    id = input.resolve_id(db, Alias, id)
-    mailbox_ids = {input.resolve_id(db, Mailbox, mb_id) for mb_id in mailboxes}
+    if (alias := input.resolve_id(db, Alias, id)) is not None:
+        id = alias.id
+
+    mailbox_ids = set()
+    for mb_id in mailboxes:
+        mailbox = input.resolve_id(db, Mailbox, mb_id)
+        try:
+            mailbox_ids.add(mailbox.id)
+        except AttributeError:
+            mailbox_ids.add(mb_id)
+
     if note == "_EDIT":
         note = input.edit()
+
     success, msg = sl.update_alias(
         alias_id=id,
         note=note,
@@ -26,4 +36,14 @@ def _update(id, note, name, mailboxes, disable_pgp, pinned):
     if not success:
         click.echo(msg)
         return False
+
+    if alias is not None:
+        # Update local db.
+        alias.note = note or alias.note
+        alias.name = name or alias.name
+        alias.disable_pgp = disable_pgp or alias.disable_pgp
+        alias.pinned = pinned or alias.pinned
+        db.session.add(alias)
+        db.session.commit()
+
     return True

--- a/simplelogincmd/cli/commands/alias_commands/contact_commands/_create.py
+++ b/simplelogincmd/cli/commands/alias_commands/contact_commands/_create.py
@@ -8,12 +8,17 @@ def _create(id, email):
     cfg = init.cfg()
     sl = init.sl(cfg)
     db = init.db(cfg)
-    id = input.resolve_id(db, Alias, id)
+    if (alias := input.resolve_id(db, Alias, id)) is not None:
+        id = alias.id
+
     success, obj = sl.create_contact(id, email)
     if not success:
         click.echo(obj)
         return False
+
+    # Update local db.
     db.session.upsert(obj)
     db.session.commit()
+
     click.echo(obj.reverse_alias_address)
     return True

--- a/simplelogincmd/cli/commands/alias_commands/contact_commands/_list.py
+++ b/simplelogincmd/cli/commands/alias_commands/contact_commands/_list.py
@@ -10,17 +10,23 @@ def _list(id, include, exclude, header):
     )
     if len(fields) == 0:
         return
+
     cfg = util.init.cfg()
     sl = util.init.sl(cfg)
     db = util.init.db(cfg)
-    id = util.input.resolve_id(db, Alias, id)
+    if (alias := util.input.resolve_id(db, Alias, id)) is not None:
+        id = alias.id
+
     contacts = sl.get_all_alias_contacts(id)
     if len(contacts) == 0:
         click.echo("No contacts found")
         return
+
+    # Update local db.
     for contact in contacts:
         db.session.upsert(contact)
     db.session.commit()
+
     pager_threshold = cfg.get("display.pager-threshold")
     if header is None:
         header = cfg.get("display.headers")

--- a/simplelogincmd/cli/commands/alias_commands/contact_commands/_toggle.py
+++ b/simplelogincmd/cli/commands/alias_commands/contact_commands/_toggle.py
@@ -8,10 +8,19 @@ def _toggle(id):
     cfg = init.cfg()
     sl = init.sl(cfg)
     db = init.db(cfg)
-    id = input.resolve_id(db, Contact, id)
+    if (contact := input.resolve_id(db, Contact, id)) is not None:
+        id = contact.id
+
     success, result = sl.toggle_contact(id)
     if not success:
         click.echo(result)
         return False
+
+    if contact is not None:
+        # Update local db.
+        contact.block_forward = result
+        db.session.add(contact)
+        db.session.commit()
+
     click.echo("Blocked" if result else "Unblocked")
     return True

--- a/simplelogincmd/cli/commands/database_commands/_sync.py
+++ b/simplelogincmd/cli/commands/database_commands/_sync.py
@@ -8,20 +8,32 @@ def _sync():
     sl = init.sl(cfg)
     db = init.db(cfg)
     objects = []
+
     click.echo("Retrieving mailboxes... ", nl=False)
     mailboxes = sl.get_mailboxes()
     objects.extend(mailboxes)
     click.echo("Done")
+
     click.echo("Retrieving aliases... ", nl=False)
     aliases = sl.get_all_aliases()
     objects.extend(aliases)
     click.echo("Done")
+
+    click.echo("Retrieving contacts... ", nl=False)
+    click.echo("Skipped")
+    click.echo(
+        "N.B., You will need to add alias contacts manually, by invoking "
+        "the `alias contact list` command, if you want to query contacts "
+        "locally."
+    )
+
     click.echo("Refreshing local database... ", nl=False)
     db.clear()
     for obj in objects:
         db.session.upsert(obj)
     db.session.commit()
     click.echo("Done")
+
     click.echo("")
     click.echo("Local database synced successfully.")
     return True

--- a/simplelogincmd/cli/commands/mailbox_commands/_delete.py
+++ b/simplelogincmd/cli/commands/mailbox_commands/_delete.py
@@ -8,13 +8,29 @@ def _delete(id, transfer_aliases_to, bypass_confirm):
     cfg = init.cfg()
     sl = init.sl(cfg)
     db = init.db(cfg)
-    id = input.resolve_id(db, Mailbox, id)
-    if transfer_aliases_to == -1 and not bypass_confirm:
-        click.confirm(
-            "This will delete all of the mailbox's aliases. Are you sure?", abort=True
-        )
+    if (mailbox := input.resolve_id(db, Mailbox, id)) is not None:
+        id = mailbox.id
+        name = mailbox.email
+    else:
+        name = id
+
+    if not bypass_confirm:
+        if transfer_aliases_to == -1:
+            click.confirm(
+                f"This will delete all of {name}'s aliases. Are you sure?",
+                abort=True,
+            )
+        else:
+            click.confirm(f"Delete {name}?", abort=True)
+
     success, msg = sl.delete_mailbox(id, transfer_aliases_to)
     if not success:
         click.echo(msg)
         return False
+
+    if mailbox is not None:
+        # Update local db.
+        db.session.delete(mailbox)
+        db.session.commit()
+
     return True

--- a/simplelogincmd/cli/commands/mailbox_commands/_update.py
+++ b/simplelogincmd/cli/commands/mailbox_commands/_update.py
@@ -8,9 +8,19 @@ def _update(id, email, default, cancel_email_change):
     cfg = init.cfg()
     sl = init.sl(cfg)
     db = init.db(cfg)
-    id = input.resolve_id(db, Mailbox, id)
+    if (mailbox := input.resolve_id(db, Mailbox, id)) is not None:
+        id = mailbox.id
+
     success, msg = sl.update_mailbox(id, email, default, cancel_email_change)
     if not success:
         click.echo(msg)
         return False
+
+    if mailbox is not None:
+        # Update local db.
+        mailbox.email = email or mailbox.email
+        mailbox.default = default or mailbox.default
+        db.session.add(mailbox)
+        db.session.commit()
+
     return True

--- a/simplelogincmd/cli/util/input.py
+++ b/simplelogincmd/cli/util/input.py
@@ -66,9 +66,8 @@ def resolve_id(db, model_cls, id):
     Call the model classes :meth:`~Object.resolve_identifier` method to
     locate db objects based on the given identifier, which can be any
     value. If multiple results match, ask the user to choose one and
-    return the id of the selected object. If one result matches, return
-    its id directly. If no matches were found, return the id as it was
-    provided.
+    return the selected object. If one result matches, return
+    it directly. If no matches were found, return None.
 
     :param db: The access layer instance to use for the lookup
     :type db: :class:`~simplelogincmd.database.DatabaseAccessLayer`
@@ -79,15 +78,14 @@ def resolve_id(db, model_cls, id):
     :type id: Any, usually int or str, as defined by the model class's
         :meth:`~simplelogincmd.database.models.Object.identifier_query`
 
-    :return: The numeric id of the matched object, or the given id if
-        none matched
-    :rtype: int | type(id)
+    :return: The matched object, or None if none matched
+    :rtype: :class:`~simplelogincmd.database.models.Object` | None
     """
     results = model_cls.resolve_identifier(db.session, id)
     count = len(results)
     if count == 0:
-        return id
+        return None
     if count == 1:
-        return results[0].id
+        return results[0]
     choice = prompt_choice(f"Select {model_cls.__name__}", results)
-    return results[choice].id
+    return results[choice]


### PR DESCRIPTION
Most delete, toggle, and update commands did not previously update the local state of objects they modify. In order to allow them to do so relatively efficiently, modify the CLI utils `resolve_id()` function to return the entire objects it locates, rather than only their numeric id. Without this change, commands that modify db objects would have needed essentially to query the same object twice (once when resolving
        the user-given identifier, and again when it comes time to
        update the db). This does, however, necessitate the
modification of all command callbacks that use this function, some unrelated to the larger goal of keeping the db in better sync. Finally,
          update the commands that were actually causing the problem
          to update and save their deleted/toggled/updated objects in
          the local database.

          One perhaps notable exception is the `cancel_email_change`
          parameter of the `mailbox update` callback, which is not
          persisted to the db, as Mailbox objects do not have this
          attribute. Indeed, I truly still do not know what that param
          does.

          DB synchronization is still not perfect after this change--
          and it probably never will be due to the ability of other
          unrelated apps to modify objects apart from this CLI--but it
          is quite a lot better.

Also add a note about contact syncing to the `database sync` command,
     so that users are informed that contacts are not synced auto-
     matically. This is due to the way SimpleLogin currently exposes
     contacts. Doing this all up front would require an unreasonable
     (and potentially limiting) number of back-to-back API requests.